### PR TITLE
Add auto reconnect functionality to sockets

### DIFF
--- a/client/src/NamespaceTree.tsx
+++ b/client/src/NamespaceTree.tsx
@@ -27,7 +27,7 @@ export interface Module {
 
 function NamespaceTree() {
     const files = useSelector<RootState, FilesState>((state) => state.files);
-    const readyState = useSelector<RootState, ReadyState>((state) => state.socket.readyState);
+    const readyState = useSelector<RootState, ReadyState>((state) => state.socket.fileSocketReadyState);
     const dispatch = useDispatch();
 
     useEffect(() => {

--- a/client/src/PyModule.tsx
+++ b/client/src/PyModule.tsx
@@ -9,7 +9,7 @@ import { ReadyState } from "./utils/Socket";
 
 export function PyModule() {
     const runningProcess = useSelector<RootState, PyProcess | null>(state => state.process.active);
-    const socketReadyState = useSelector<RootState, ReadyState>(state => state.socket.readyState);
+    const socketReadyState = useSelector<RootState, ReadyState>(state => state.socket.fileSocketReadyState);
     const moduleName = useLoaderData();
     const location = useLocation();
     const dispatch = useDispatch();

--- a/client/src/app/store.ts
+++ b/client/src/app/store.ts
@@ -15,7 +15,7 @@ const store = configureStore({
         module: moduleReducer,
     },
     middleware: (getDefaultMiddleware) => getDefaultMiddleware()
-        .concat([websocketMiddlewareFactory(new Socket()), runsocketMiddlewareFactory()])
+        .concat([websocketMiddlewareFactory(), runsocketMiddlewareFactory()])
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/client/src/features/socket.ts
+++ b/client/src/features/socket.ts
@@ -2,22 +2,27 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { ReadyState } from '../utils/Socket';
 
 export interface SocketState {
-    readyState: ReadyState;
+    fileSocketReadyState: ReadyState;
+    runSocketReadyState: ReadyState;
 }
 
 const initialState: SocketState = {
-    readyState: ReadyState.UNINITIALIZED
+    fileSocketReadyState: ReadyState.CLOSED,
+    runSocketReadyState: ReadyState.CLOSED
 }
 
 const socketSlice = createSlice({
     name: 'socket',
     initialState,
     reducers: {
-        updateReadyState(state, action: PayloadAction<ReadyState>) {
-            state.readyState = action.payload;
+        updateFileReadyState(state, action: PayloadAction<ReadyState>) {
+            state.fileSocketReadyState = action.payload;
+        },
+        updateRunReadyState(state, action: PayloadAction<ReadyState>) {
+            state.runSocketReadyState = action.payload;
         }
     }
 });
 
-export const { updateReadyState } = socketSlice.actions;
+export const { updateFileReadyState, updateRunReadyState } = socketSlice.actions;
 export default socketSlice.reducer;

--- a/client/src/home/Home.tsx
+++ b/client/src/home/Home.tsx
@@ -2,9 +2,9 @@ import { Icon } from "@iconify/react/dist/iconify.js";
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
-import { SocketState } from "../features/socket";
 import { RootState } from "../app/store";
 import { ModuleState } from "../features/module";
+import { ReadyState } from "../utils/Socket";
 
 export interface HomeContext {
     navigateToModule: (module: string) => void;
@@ -13,7 +13,7 @@ export interface HomeContext {
 export function Home() {
     const module = useSelector<RootState, ModuleState>((state) => state.module);
     const dispatch = useDispatch();
-    const { readyState } = useSelector<RootState, SocketState>((state) => state.socket);
+    const readyState = useSelector<RootState, ReadyState>((state) => state.socket.fileSocketReadyState);
 
     // const [module, setModule] = useState<string | null>(null);
     const navigate = useNavigate();

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .disabled {
+    opacity: 75%;
+    pointer-events: none;
+  }
+}
+
 /* :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/client/src/middleware/runsocket.ts
+++ b/client/src/middleware/runsocket.ts
@@ -1,5 +1,5 @@
 import { Socket } from '../utils/Socket';
-// import { updateReadyState } from '../features/socket';
+import { updateRunReadyState } from '../features/socket';
 
 import { updateProcessState, appendStdIO, clearStdIO, setProcess } from '../features/process';
 import { PyProcessState } from '../PyProcess';
@@ -12,9 +12,9 @@ export const runsocketMiddlewareFactory = () => {
 
     return (params: any) => {
         const { dispatch, getState } = params;
-        // function setReadyState(readyState: number) {
-        //     // dispatch(updateReadyState(readyState));
-        // }
+        function setReadyState(readyState: number) {
+            dispatch(updateRunReadyState(readyState));
+        }
 
         return (next: any) => (action: any) => {
             const { type, payload } = action as { type: string, payload: any };
@@ -30,13 +30,12 @@ export const runsocketMiddlewareFactory = () => {
                     const endpoint = payload.endpoint as string;
                     const module = payload.module as string;
 
-                    socket = new Socket(endpoint);
+                    socket = new Socket(endpoint, 1000);
 
-                    // setReadyState(0);
+                    setReadyState(WebSocket.CONNECTING);
                     socket.connect();
-                    dispatch(setProcess({ pid: 0, module: module, path: 'TODO', state: PyProcessState.STARTING }));
 
-                    socket.on('open', () => { });
+                    dispatch(setProcess({ pid: 0, module: module, path: 'TODO', state: PyProcessState.STARTING }));
 
                     socket.on('message', (data: MessageEvent) => {
                         const message = parseJsonMessage(data);
@@ -85,12 +84,16 @@ export const runsocketMiddlewareFactory = () => {
                         }
                     });
 
-                    socket.on('error', () => {
-                        // setReadyState(WebSocket.CLOSED);
+                    socket.on('open', () => {
+                        setReadyState(WebSocket.OPEN);
                     });
 
-                    socket.on('closed', () => {
-                        // setReadyState(WebSocket.CLOSED);
+                    socket.on('error', () => {
+                        setReadyState(WebSocket.CLOSED);
+                    });
+
+                    socket.on('close', () => {
+                        setReadyState(WebSocket.CLOSED);
                     });
                     break;
 
@@ -99,7 +102,7 @@ export const runsocketMiddlewareFactory = () => {
                     break;
 
                 case 'runsocket/disconnect':
-                    // setReadyState(2);
+                    setReadyState(WebSocket.CLOSING);
                     socket?.disconnect();
                     break;
 

--- a/client/src/middleware/runsocket.ts
+++ b/client/src/middleware/runsocket.ts
@@ -32,6 +32,7 @@ export const runsocketMiddlewareFactory = () => {
 
                     socket = new Socket(endpoint, 1000);
 
+                    dispatch(clearStdIO());
                     setReadyState(WebSocket.CONNECTING);
                     socket.connect();
 

--- a/client/src/middleware/runsocket.ts
+++ b/client/src/middleware/runsocket.ts
@@ -29,7 +29,7 @@ export const runsocketMiddlewareFactory = () => {
                         socket.disconnect();
                     }
                     const endpoint = payload.endpoint as string;
-                    socket = new Socket(endpoint);
+                    socket = new Socket(endpoint, 1000);
 
                     setReadyState(0);
                     socket.connect();

--- a/client/src/middleware/websocket.ts
+++ b/client/src/middleware/websocket.ts
@@ -1,7 +1,7 @@
 import { Socket } from '../utils/Socket';
 import { parseJsonMessage } from '../Message';
 import { update as setFiles } from '../features/files';
-import { updateReadyState } from '../features/socket';
+import { updateFileReadyState } from '../features/socket';
 import router from "../routes";
 
 // Explained in far more detail here: https://www.taniarascia.com/websockets-in-redux/
@@ -14,7 +14,7 @@ export const websocketMiddlewareFactory = () => {
         const { type, payload } = action;
 
         function setReadyState(readyState: number) {
-            dispatch(updateReadyState(readyState));
+            dispatch(updateFileReadyState(readyState));
         }
 
         switch (type) {
@@ -26,7 +26,7 @@ export const websocketMiddlewareFactory = () => {
 
                 socket = new Socket('/ws', 1000);
 
-                setReadyState(0);
+                setReadyState(WebSocket.CONNECTING);
                 socket.connect();
 
                 socket.on('message', (data: MessageEvent) => {
@@ -51,22 +51,22 @@ export const websocketMiddlewareFactory = () => {
                 });
 
                 socket.on('open', () => {
-                    setReadyState(1);
+                    setReadyState(WebSocket.OPEN);
                 });
 
                 socket.on('close', () => {
-                    setReadyState(3);
+                    setReadyState(WebSocket.CLOSED);
                 });
 
                 socket.on('error', () => {
-                    setReadyState(3);
+                    setReadyState(WebSocket.CLOSED);
                 });
                 break;
             case 'socket/send':
                 socket?.send(payload);
                 break;
             case 'socket/disconnect':
-                setReadyState(2);
+                setReadyState(WebSocket.CLOSING);
                 socket?.disconnect();
                 break;
             default:

--- a/client/src/middleware/websocket.ts
+++ b/client/src/middleware/websocket.ts
@@ -5,68 +5,74 @@ import { updateReadyState } from '../features/socket';
 import router from "../routes";
 
 // Explained in far more detail here: https://www.taniarascia.com/websockets-in-redux/
-export const websocketMiddlewareFactory = (socket: Socket) => (params: any) => (next: any) => (action: any) => {
-    const { dispatch } = params;
-    const { type, payload } = action;
+export const websocketMiddlewareFactory = () => {
+    console.log("File socket initialized");
+    let socket: Socket | null;
 
-    function setReadyState(readyState: number) {
-        dispatch(updateReadyState(readyState));
-    }
+    return (params: any) => (next: any) => (action: any) => {
+        const { dispatch } = params;
+        const { type, payload } = action;
 
-    switch (type) {
-        case 'socket/connect':
-            // So we don't add duplicate event listeners
-            if (socket.isConnected()) {
-                return;
-            }
+        function setReadyState(readyState: number) {
+            dispatch(updateReadyState(readyState));
+        }
 
-            setReadyState(0);
-            socket.connect();
-
-            socket.on('message', (data: MessageEvent) => {
-                const message = parseJsonMessage(data);
-                if (!message) {
-                    return;
+        switch (type) {
+            case 'socket/connect':
+                // So we don't add duplicate event listeners
+                if (socket) {
+                    socket.disconnect();
                 }
 
-                // const { process } = getState() as RootState;
-                switch (message.type) {
-                    case 'LS':
-                        dispatch(setFiles(message.data.files));
-                        break;
-                    case 'directory_modified':
-                        socket.send({ type: "LS", data: { path: "/" } });
-                        break;
-                    case 'file_modified':
-                        router.navigate(".", { replace: true });
-                        break;
+                socket = new Socket('/ws', 1000);
 
-                }
-            });
+                setReadyState(0);
+                socket.connect();
 
-            socket.on('open', () => {
-                setReadyState(1);
-            });
+                socket.on('message', (data: MessageEvent) => {
+                    const message = parseJsonMessage(data);
+                    if (!message) {
+                        return;
+                    }
 
-            socket.on('close', () => {
-                setReadyState(3);
-            });
+                    // const { process } = getState() as RootState;
+                    switch (message.type) {
+                        case 'LS':
+                            dispatch(setFiles(message.data.files));
+                            break;
+                        case 'directory_modified':
+                            socket?.send({ type: "LS", data: { path: "/" } });
+                            break;
+                        case 'file_modified':
+                            router.navigate(".", { replace: true });
+                            break;
 
-            socket.on('error', () => {
-                setReadyState(3);
-            });
-            break;
-        case 'socket/send':
+                    }
+                });
 
-            socket.send(payload);
-            break;
-        case 'socket/disconnect':
-            setReadyState(2);
-            socket.disconnect();
-            break;
-        default:
-            break;
+                socket.on('open', () => {
+                    setReadyState(1);
+                });
+
+                socket.on('close', () => {
+                    setReadyState(3);
+                });
+
+                socket.on('error', () => {
+                    setReadyState(3);
+                });
+                break;
+            case 'socket/send':
+                socket?.send(payload);
+                break;
+            case 'socket/disconnect':
+                setReadyState(2);
+                socket?.disconnect();
+                break;
+            default:
+                break;
+        }
+
+        return next(action);
     }
-
-    return next(action);
 }

--- a/client/src/utils/Socket.ts
+++ b/client/src/utils/Socket.ts
@@ -94,7 +94,7 @@ class Socket {
 
     private heartbeatPollLoop() {
         const controller = new AbortController();
-        setTimeout(() => controller.abort(), 500);
+        setTimeout(() => controller.abort(), 1000);
 
         console.log(`Connection lost. Pinging heartbeat and waiting ${this.reconnectTimeout}ms before repolling.`);
 

--- a/client/src/utils/Socket.ts
+++ b/client/src/utils/Socket.ts
@@ -31,7 +31,7 @@ class Socket {
         }
 
         if (this.reconnectTimeout > 0) {
-            this.socket.addEventListener("close", this.autoReconnect.bind(this));
+            this.socket.addEventListener("close", this.autoReconnectHandler.bind(this));
         }
     }
 
@@ -42,7 +42,7 @@ class Socket {
     disconnect() {
         if (this.socket) {
             this.eventHandlers = {};
-            this.socket.removeEventListener('close', this.autoReconnect);
+            this.socket.removeEventListener('close', this.autoReconnectHandler);
             this.socket.close();
         }
 
@@ -82,8 +82,8 @@ class Socket {
         }
     }
 
-    private autoReconnect() {
-        if (this.reconnectTimeout < 0) {
+    private autoReconnectHandler(event: CloseEvent) {
+        if (this.reconnectTimeout < 0 || event.code === 1000) {
             return;
         }
 

--- a/client/src/utils/Socket.ts
+++ b/client/src/utils/Socket.ts
@@ -1,9 +1,20 @@
 import { Message } from "../Message";
 
+interface EventHandlerCollection {
+    [evt: string]: ((data?: any) => {})[]
+}
+
+const WebSocketEvents = ["close", "error", "message", "open"];
+
 class Socket {
     socket: WebSocket | null = null
+    eventHandlers: EventHandlerCollection = {};
 
-    constructor(private path: string = "/ws") { }
+    // Any negative value for reconnectTimeout indicates it should not try to reconnect
+    constructor(
+        private path: string = "/ws",
+        private reconnectTimeout: number = -1
+    ) { }
 
     connect() {
         if (this.socket) {
@@ -14,6 +25,14 @@ class Socket {
         const PROTOCOL = window.location.protocol === 'http:' ? 'ws:' : 'wss:';
         const WS_ENDPOINT = `${PROTOCOL}//${HOST}${this.path}`;
         this.socket = new WebSocket(WS_ENDPOINT);
+
+        for (let eventName of WebSocketEvents) {
+            this.socket.addEventListener(eventName, this.handleEvent.bind(this, eventName));
+        }
+
+        if (this.reconnectTimeout > 0) {
+            this.socket.addEventListener("close", this.autoReconnect.bind(this));
+        }
     }
 
     isConnected() {
@@ -22,9 +41,13 @@ class Socket {
 
     disconnect() {
         if (this.socket) {
+            this.eventHandlers = {};
+            this.socket.removeEventListener('close', this.autoReconnect);
             this.socket.close();
-            this.socket = null;
         }
+
+        this.reconnectTimeout = -1;
+        this.socket = null;
     }
 
     send(message: Message) {
@@ -34,9 +57,42 @@ class Socket {
     }
 
     on(eventName: string, callback: any) {
-        if (this.socket) {
-            this.socket.addEventListener(eventName, callback);
+        if (this.eventHandlers[eventName]) {
+            this.eventHandlers[eventName].push(callback);
+        } else {
+            this.eventHandlers[eventName] = [callback];
         }
+    }
+
+    readyState() {
+        if (this.socket) {
+            return this.socket.readyState;
+        }
+    }
+
+    private handleEvent(eventName: string, data: any) {
+        if (!this.eventHandlers[eventName]) {
+            return;
+        }
+
+        for (let handler of this.eventHandlers[eventName]) {
+            setTimeout(() => {
+                handler(data);
+            }, 0);
+        }
+    }
+
+    private autoReconnect() {
+        if (this.reconnectTimeout < 0) {
+            return;
+        }
+
+        console.log(`Connection lost. Attempting reconnect in ${this.reconnectTimeout}ms`);
+        this.socket = null;
+
+        setTimeout(() => {
+            this.connect();
+        }, this.reconnectTimeout);
     }
 }
 

--- a/client/src/utils/Socket.ts
+++ b/client/src/utils/Socket.ts
@@ -97,7 +97,6 @@ class Socket {
 }
 
 const enum ReadyState {
-    UNINITIALIZED = -1,
     CONNECTING = 0,
     OPEN = 1,
     CLOSING = 2,

--- a/server/src/trailhead/app.py
+++ b/server/src/trailhead/app.py
@@ -54,6 +54,11 @@ async def get_module(module: str) -> Module:
         return analyze_module(path)
 
 
+@app.get("/api/heartbeat")
+async def get_heartbeat():
+    return "heartbeat"
+
+
 @app.websocket("/ws/{module}/run")
 async def run_module(module: str, client: WebSocket):
     """The FastAPI web socket endpoint dispatches out to Web Socket Manager."""


### PR DESCRIPTION
Socket utility class required somewhat of a rewrite so handlers are now attached to it instead of directly to the socket. This allows the Socket utility class to create a new WebSocket connections internally if the old one drops, and keep the old event handlers.