### PR TITLE
Fix to encode/decode url to handle filenames with spaces

### DIFF
--- a/client/src/NamespaceTree.tsx
+++ b/client/src/NamespaceTree.tsx
@@ -45,7 +45,7 @@ function NamespaceTree() {
             switch (item.ns_type) {
                 case 'module':
                     children.push(<li key={item.full_path + item.name}>
-                        <NavLink to={"./module/" + item.full_path.substring(2).replace("\/", ".").replace(".py", "")} className="w-full grid grid-cols-4 hover:bg-neutral-100">
+                        <NavLink to={"./module/" + encodeURIComponent(item.full_path.substring(2).replace("\/", ".").replace(".py", ""))} className="w-full grid grid-cols-4 hover:bg-neutral-100">
                             <span className="col-span-1">{item.name.replace(".py", "")}</span>
                             <span className="text-neutral-400 font-light italic col-span-3 overflow-hidden text-ellipsis text-nowrap">{item.docstring}</span>
                         </NavLink>

--- a/client/src/api/module.ts
+++ b/client/src/api/module.ts
@@ -46,7 +46,7 @@ export const moduleLoader = async ({ params, request }: any) => {
         /* The auto-redirect is only meant at the top-route level of the module, not at the individual
            tools which we are redirecting to. */
         const windowLocation = window.location.protocol + "//" + window.location.host;
-        const requestUrl = request.url.replace(windowLocation, "");
+        const requestUrl = decodeURIComponent(request.url.replace(windowLocation, ""));
         if (target === requestUrl) {
             if (moduleInfo.top_level_calls && moduleInfo.top_level_calls.length > 0) {
                 target += "/run";


### PR DESCRIPTION
When trying to run a script with a space in the name, the url get's automatically encoded with the space, and redirected just fine. However, the moduleLoader route function didn't explicitly decode it, and as such compare the URL encoded version against the non-encoded version at the `if (target === requestUrl)` line.

This change adds explicit URL decoding to requestURL before checking it against target, along with explicit encoding in the NamespaceTree component. This second change isn't required, but makes things a little clearer and doesn't hurt.