### PR TITLE
Fix syntax error causing home page issues

### DIFF
--- a/server/src/trailhead/analysis/inspect.py
+++ b/server/src/trailhead/analysis/inspect.py
@@ -38,8 +38,16 @@ def main() -> None:
 
 def analyze_module(file: str) -> Module:
     with open(file) as f:
-        tree = ast.parse(f.read())
-        return get_module(file, tree)
+        try:
+            tree = ast.parse(f.read())
+            return get_module(file, tree)
+        except SyntaxError:
+            return Module(
+                name=file,
+                doc="SyntaxError encountered when parsing",
+                top_level_functions=[],
+                top_level_calls=[],
+            )
 
 
 def get_module(path: str, tree: ast.Module) -> Module:

--- a/server/src/trailhead/analysis/inspect.py
+++ b/server/src/trailhead/analysis/inspect.py
@@ -41,10 +41,10 @@ def analyze_module(file: str) -> Module:
         try:
             tree = ast.parse(f.read())
             return get_module(file, tree)
-        except SyntaxError:
+        except Exception as e:
             return Module(
                 name=file,
-                doc="SyntaxError encountered when parsing",
+                doc=f"{type(e).__name__} encountered when parsing",
                 top_level_functions=[],
                 top_level_calls=[],
             )

--- a/server/src/trailhead/controller.py
+++ b/server/src/trailhead/controller.py
@@ -57,8 +57,8 @@ def _get_docstring_by_path(path: str) -> str:
         try:
             tree = ast.parse(f.read())
             return ast.get_docstring(tree) or ""
-        except SyntaxError:
-            return "SyntaxError encountered when parsing"
+        except Exception as e:
+            return f"{type(e).__name__} encountered when parsing"
 
 
 async def list_files_async(directory: str) -> NamespaceTree:

--- a/server/src/trailhead/controller.py
+++ b/server/src/trailhead/controller.py
@@ -54,8 +54,11 @@ def _get_docstring_by_path(path: str) -> str:
     if not path_obj.exists():
         return ""
     with open(path) as f:
-        tree = ast.parse(f.read())
-        return ast.get_docstring(tree) or ""
+        try:
+            tree = ast.parse(f.read())
+            return ast.get_docstring(tree) or ""
+        except SyntaxError:
+            return "SyntaxError encountered when parsing"
 
 
 async def list_files_async(directory: str) -> NamespaceTree:


### PR DESCRIPTION
Before, potential errors (namely syntax errors) weren't being caught from `ast.parse`. Calls to `ast.parse` are now wrapped in a `try` `except` so that if an error is found, it's handled gracefully and doesn't affect other modules' docstrings from showing up.

Also, errors being caught should not prevent the module from being run, as it would likely be beneficial to students to still be able to run the program to get more info on their errors. This is why `inspect.py` will return a dummy Module when an error is caught now, so the frontend still views it as a runnable module.