### PR TITLE
Fix UnionType parameters causing errors when parsed

### DIFF
--- a/server/src/trailhead/wrappers/repl.py
+++ b/server/src/trailhead/wrappers/repl.py
@@ -125,7 +125,7 @@ def decompose_function(value: FunctionType) -> Function:
         parameters.append(
             Parameter(
                 name=name,
-                type=param.annotation.__name__
+                type=getattr(param.annotation, "__name__", str(param.annotation))
                 if param.annotation != inspect._empty
                 else "Any",
                 default_value=None


### PR DESCRIPTION
Error was caused by function parameters with UnionType's being parsed as if they contained a `__name__` attribute. UnionType's don't have these, and instead the equivalent must be retrieved by passing a UnionType to the `str` function.

Fixes issue #25 