### PR TITLE
Add CLI-like input history functionality with arrow keys

### DIFF
--- a/client/src/features/process.ts
+++ b/client/src/features/process.ts
@@ -5,14 +5,18 @@ import { StdIO, StdOut, StdOutGroup } from '../StdIOTypes';
 // StdOutGroups are handled internally for display only - we only want to accept StdOut
 type StdIOUpdate = Exclude<StdIO, StdOutGroup> | StdOut;
 
+const maxInputHistorySize = 100;
+
 export interface ProcessState {
     active: PyProcess | null;
     stdio: StdIO[];
+    inputHistory: string[];
 }
 
 const initialState: ProcessState = {
     active: null,
-    stdio: []
+    stdio: [],
+    inputHistory: []
 }
 
 const processSlice = createSlice({
@@ -67,6 +71,11 @@ const processSlice = createSlice({
             const line = state.stdio[lineIndex];
             if (line.type === 'stdin') {
                 line.response = stdinValue;
+
+                state.inputHistory.unshift(stdinValue);
+                if (state.inputHistory.length > maxInputHistorySize) {
+                    state.inputHistory.pop();
+                }
             } else {
                 throw new Error("Expected line === stdinLine");
             }


### PR DESCRIPTION
These changes add input history functionality, just like in a command line. A user can hit the up and down arrow's to switch between recent inputs.

In the current implementation, input history will not reset unless the page is refreshed, even if the current process stops/changes. The maximum history length right now is 100 entries (arbitrarily chosen), and is controlled by a new constant declared in `process.ts`.