### PR TITLE
Add GUI functionality to Trailhead

### DIFF
--- a/client/src/GraphicalUI.tsx
+++ b/client/src/GraphicalUI.tsx
@@ -1,0 +1,35 @@
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "./app/store";
+import { ExprEval, StdIO } from "./StdIOTypes";
+import { PyProcess } from "./PyProcess";
+import { ModuleInfo } from "./features/module";
+
+export function GraphicalUI() {
+    const pyProcess = useSelector<RootState, PyProcess | null>((state) => state.process.active);
+    const moduleInfo = useSelector<RootState, ModuleInfo | null>((state) => state.module.info);
+    const stdio = useSelector<RootState, ExprEval[]>((state) => state.process.stdio.filter(line => line.type === "expr_eval") as ExprEval[]);
+    const dispatch = useDispatch();
+
+    function sendTest() {
+        dispatch({
+            type: 'runsocket/send',
+            payload: { type: "STDIN", "data": { "data": "my_func()", "pid": pyProcess?.pid } }
+        });
+    }
+    return <div>
+        {/* {stdio.map((line, idx) => {
+            return <div key={idx}>{JSON.stringify(line.value)}</div>
+        })} */}
+        {/* This is where the UI goes
+        <br></br>
+        {stdio.length > 0 && JSON.stringify(stdio[stdio.length - 1].value)}
+        <div className="btn btn-primary ml-4" onClick={sendTest}>Click Me</div> */}
+        {
+            moduleInfo?.global_vars?.["__template__"] ? (
+                <iframe className="w-full h-[70vh]" src={moduleInfo?.global_vars?.["__template__"]}></iframe>
+            ) : (
+                <div>No <code className="bg-base-300 p-1 rounded">__template__</code> variable declared.</div>
+            )
+        }
+    </div>;
+}

--- a/client/src/GraphicalUI.tsx
+++ b/client/src/GraphicalUI.tsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "./app/store";
 import { ExprEval, StdIO } from "./StdIOTypes";
-import { PyProcess } from "./PyProcess";
+import { PyProcess, PyProcessState } from "./PyProcess";
 import { ModuleInfo } from "./features/module";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { StdOutGroupContainer } from "./StdOutGroupContainer";
@@ -71,7 +71,16 @@ export function GraphicalUI() {
     useEffect(() => {
         if (guiIframe === null) return;
 
-        guiIframe.src = guiIframe?.src;
+        if (pyProcess?.state === PyProcessState.RUNNING) {
+            guiIframe.src = guiIframe?.src;
+
+            setMessageHistory([]);
+
+            guiIframe.contentWindow?.postMessage({
+                source: "gui-template-parent",
+                payload: "ready"
+            }, "*");
+        }
     }, [pyProcess]);
 
     useEffect(() => {

--- a/client/src/GraphicalUI.tsx
+++ b/client/src/GraphicalUI.tsx
@@ -3,19 +3,61 @@ import { RootState } from "./app/store";
 import { ExprEval, StdIO } from "./StdIOTypes";
 import { PyProcess } from "./PyProcess";
 import { ModuleInfo } from "./features/module";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export function GraphicalUI() {
     const pyProcess = useSelector<RootState, PyProcess | null>((state) => state.process.active);
     const moduleInfo = useSelector<RootState, ModuleInfo | null>((state) => state.module.info);
+    const [guiIframe, setGuiIframe] = useState<HTMLIFrameElement | null>(null);
     const stdio = useSelector<RootState, ExprEval[]>((state) => state.process.stdio.filter(line => line.type === "expr_eval") as ExprEval[]);
+    const prevStdioLength = useRef<number>(stdio.length);
     const dispatch = useDispatch();
 
-    function sendTest() {
+    // function sendTest() {
+    //     dispatch({
+    //         type: 'runsocket/send',
+    //         payload: { type: "STDIN", "data": { "data": "my_func()", "pid": pyProcess?.pid } }
+    //     });
+    // }
+
+    const handleIframe = useCallback((iframe: HTMLIFrameElement | null) => {
+        setGuiIframe(iframe);
+    }, []);
+
+    function handleMessageFromChild(event: MessageEvent<{ source: string, payload: string }>) {
+        if (event.data?.source !== "gui-template-child") return;
+
         dispatch({
             type: 'runsocket/send',
-            payload: { type: "STDIN", "data": { "data": "my_func()", "pid": pyProcess?.pid } }
+            payload: { type: "STDIN", "data": { "data": event.data.payload, "pid": pyProcess?.pid } }
         });
     }
+
+    useEffect(() => {
+        window.addEventListener('message', handleMessageFromChild);
+
+        return () => {
+            window.removeEventListener('message', handleMessageFromChild);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (guiIframe === null || stdio.length === prevStdioLength.current || stdio.length <= 0) return;
+
+        guiIframe.contentWindow?.postMessage({
+            source: "gui-template-parent",
+            payload: stdio[stdio.length - 1].value
+        }, "*");
+
+        prevStdioLength.current = stdio.length;
+    }, [stdio, guiIframe]);
+
+    useEffect(() => {
+        if (guiIframe === null) return;
+
+        guiIframe.src = guiIframe?.src;
+    }, [pyProcess]);
+
     return <div>
         {/* {stdio.map((line, idx) => {
             return <div key={idx}>{JSON.stringify(line.value)}</div>
@@ -24,9 +66,12 @@ export function GraphicalUI() {
         <br></br>
         {stdio.length > 0 && JSON.stringify(stdio[stdio.length - 1].value)}
         <div className="btn btn-primary ml-4" onClick={sendTest}>Click Me</div> */}
+        {pyProcess?.state}
+        <br></br>
+        {/* {JSON.stringify(stdio)} */}
         {
             moduleInfo?.global_vars?.["__template__"] ? (
-                <iframe className="w-full h-[70vh]" src={moduleInfo?.global_vars?.["__template__"]}></iframe>
+                <iframe className="w-full h-[70vh] border-2 border-black" src={moduleInfo?.global_vars?.["__template__"]} ref={handleIframe}></iframe>
             ) : (
                 <div>No <code className="bg-base-300 p-1 rounded">__template__</code> variable declared.</div>
             )

--- a/client/src/ModuleContext.tsx
+++ b/client/src/ModuleContext.tsx
@@ -1,14 +1,20 @@
+import { useSelector } from "react-redux";
 import { NavLink, Outlet, useLoaderData } from "react-router-dom";
+import { RootState } from "./app/store";
+import { ModuleInfo } from "./features/module";
 
 const activeTabClass = 'tab tab-active bg-secondary font-bold text-white rounded-box';
 
 export function ModuleContext() {
+    const moduleInfo = useSelector<RootState, ModuleInfo | null>((state) => state.module.info);
     const moduleName = useLoaderData();
     return <div>
         <div role="tablist" className="tabs tabs-lg mb-2">
             <NavLink to="./run" role="tab" className={({ isActive }) => isActive ? activeTabClass : 'tab'}>Run</NavLink>
             <NavLink to="./repl" role="tab" className={({ isActive }) => isActive ? activeTabClass : 'tab'} aria-label="Interact">Interact</NavLink>
-            <NavLink to="./gui" role="tab" className={({ isActive }) => isActive ? activeTabClass : 'tab'}>GUI</NavLink>
+            {moduleInfo?.global_vars?.["__template__"] && (
+                <NavLink to="./gui" role="tab" className={({ isActive }) => isActive ? activeTabClass : 'tab'}>GUI</NavLink>
+            )}
         </div>
         <div role="tabpanel" className="bg-base-100 border-base-300 rounded-box p-6">
             <Outlet context={{ module: moduleName }} />

--- a/client/src/ModuleContext.tsx
+++ b/client/src/ModuleContext.tsx
@@ -8,6 +8,7 @@ export function ModuleContext() {
         <div role="tablist" className="tabs tabs-lg mb-2">
             <NavLink to="./run" role="tab" className={({ isActive }) => isActive ? activeTabClass : 'tab'}>Run</NavLink>
             <NavLink to="./repl" role="tab" className={({ isActive }) => isActive ? activeTabClass : 'tab'} aria-label="Interact">Interact</NavLink>
+            <NavLink to="./gui" role="tab" className={({ isActive }) => isActive ? activeTabClass : 'tab'}>GUI</NavLink>
         </div>
         <div role="tabpanel" className="bg-base-100 border-base-300 rounded-box p-6">
             <Outlet context={{ module: moduleName }} />

--- a/client/src/StdIOTypes.ts
+++ b/client/src/StdIOTypes.ts
@@ -19,6 +19,7 @@ export type StdIn = {
 export type ExprEval = {
     type: 'expr_eval';
     value: PythonValue;
+    raw_value?: any;
 }
 
 export type StdOutGroup = {

--- a/client/src/api/module.ts
+++ b/client/src/api/module.ts
@@ -1,4 +1,4 @@
-import { ModuleInfo, clearModule, setModule } from "../features/module";
+import module, { ModuleInfo, clearModule, setModule } from "../features/module";
 import store from "../app/store";
 import router from "../routes";
 
@@ -24,6 +24,17 @@ export const replLoader = async ({ params }: any) => {
     return null;
 };
 
+export const guiLoader = async ({ params }: any) => {
+    store.dispatch({
+        type: "runsocket/connect",
+        payload: {
+            module: params.moduleName,
+            endpoint: `/ws/${params.moduleName}/repl_gui`
+        }
+    });
+    return null;
+}
+
 export const moduleLoader = async ({ params, request }: any) => {
     if (params.moduleName) {
         // Load the module info
@@ -48,7 +59,9 @@ export const moduleLoader = async ({ params, request }: any) => {
         const windowLocation = window.location.protocol + "//" + window.location.host;
         const requestUrl = decodeURIComponent(request.url.replace(windowLocation, ""));
         if (target === requestUrl) {
-            if (moduleInfo.top_level_calls && moduleInfo.top_level_calls.length > 0) {
+            if (moduleInfo.global_vars?.["__template__"]) {
+                target += "/gui";
+            } else if (moduleInfo.top_level_calls && moduleInfo.top_level_calls.length > 0) {
                 target += "/run";
             } else if (moduleInfo.top_level_functions && moduleInfo.top_level_functions.length > 0) {
                 target += "/repl";

--- a/client/src/features/module.ts
+++ b/client/src/features/module.ts
@@ -92,6 +92,7 @@ export interface ModuleInfo {
     doc: string;
     top_level_functions: any[];
     top_level_calls: string[];
+    global_vars: { [key: string]: any };
 }
 
 export interface ModuleState {

--- a/client/src/middleware/runsocket.ts
+++ b/client/src/middleware/runsocket.ts
@@ -79,7 +79,7 @@ export const runsocketMiddlewareFactory = () => {
                                     }
 
                                     if (parsed.type && parsed.type === 'expr_eval') {
-                                        dispatch(appendStdIO({ type: 'expr_eval', value: parsed.value }))
+                                        dispatch(appendStdIO({ type: 'expr_eval', value: parsed.value, raw_value: parsed.raw_value }))
                                         return
                                     }
                                 } catch (e) { /* No op */ }

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -1,11 +1,12 @@
 import { createBrowserRouter } from "react-router-dom";
 import { ModuleContext } from "./ModuleContext";
 import { ModuleRunner } from "./ModuleRunner";
-import { moduleLoader, runLoader, replLoader } from "./api/module";
+import { moduleLoader, runLoader, replLoader, guiLoader } from "./api/module";
 import { ModuleREPL } from "./ModuleREPL";
 import { ModuleIndex } from "./ModuleIndex";
 import { Home } from "./home/Home";
 import { HomeIndex } from "./home/HomeIndex";
+import { GraphicalUI } from "./GraphicalUI";
 
 
 
@@ -37,6 +38,11 @@ const router = createBrowserRouter([
                         path: "repl",
                         loader: replLoader,
                         element: <ModuleREPL />
+                    },
+                    {
+                        path: "gui",
+                        loader: guiLoader,
+                        element: <GraphicalUI />
                     }
                 ]
             }

--- a/demo/gui.py
+++ b/demo/gui.py
@@ -1,0 +1,11 @@
+"""GUI"""
+
+__framework__: str = "./my_bundle.js"
+__template__ = "https://example.com/"
+x: int = 0
+
+
+def my_func() -> list[str]:
+    global x
+    x += 1
+    return ["hallo", "there", x]

--- a/docs/bridge.ts
+++ b/docs/bridge.ts
@@ -1,15 +1,45 @@
-const messageQueue: [((arg: any) => void)?] = [];
-window.addEventListener(
-    "message",
-    (event: MessageEvent<{ source: string; payload: any }>) => {
-        if (event.data.source !== "gui-template-parent") return;
+const messageQueue: [{ code: string, handler: ((arg: any) => void) }?] = [];
+let readyToSend = false;
 
-        if (messageQueue.length > 0) {
-            const handler = messageQueue.shift()!;
-            handler(event.data.payload);
-        }
-    },
-);
+function waitForReady(event: MessageEvent<{ source: string; payload: any }>) {
+    if (event.data.source !== "gui-template-parent" || event.data.payload !== "ready") return;
+
+    window.removeEventListener("message", waitForReady);
+    readyToSend = true;
+
+    window.addEventListener(
+        "message",
+        (event: MessageEvent<{ source: string; payload: any }>) => {
+            if (event.data.source !== "gui-template-parent") return;
+
+            readyToSend = true;
+
+            if (messageQueue.length > 0) {
+                const message = messageQueue.shift()!;
+                message.handler(event.data.payload);
+                sendMessage();
+            }
+        },
+    );
+
+    sendMessage();
+}
+
+window.addEventListener("message", waitForReady);
+
+function sendMessage() {
+    if (!readyToSend || messageQueue.length <= 0) return;
+
+    readyToSend = false;
+
+    window.parent.postMessage(
+        {
+            source: "gui-template-child",
+            payload: messageQueue[0]?.code,
+        },
+        "*",
+    );
+}
 
 export function executeCode<T>(code: string) {
     return new Promise<T>((res, rej) => {
@@ -17,14 +47,11 @@ export function executeCode<T>(code: string) {
             res(payload);
         }
 
-        messageQueue.push(receivePayload);
+        messageQueue.push({
+            code: code,
+            handler: receivePayload
+        });
 
-        window.parent.postMessage(
-            {
-                source: "gui-template-child",
-                payload: code,
-            },
-            "*",
-        );
+        sendMessage();
     });
 }

--- a/docs/bridge.ts
+++ b/docs/bridge.ts
@@ -1,0 +1,30 @@
+const messageQueue: [((arg: any) => void)?] = [];
+window.addEventListener(
+    "message",
+    (event: MessageEvent<{ source: string; payload: any }>) => {
+        if (event.data.source !== "gui-template-parent") return;
+
+        if (messageQueue.length > 0) {
+            const handler = messageQueue.shift()!;
+            handler(event.data.payload);
+        }
+    },
+);
+
+export function executeCode<T>(code: string) {
+    return new Promise<T>((res, rej) => {
+        function receivePayload(payload: T) {
+            res(payload);
+        }
+
+        messageQueue.push(receivePayload);
+
+        window.parent.postMessage(
+            {
+                source: "gui-template-child",
+                payload: code,
+            },
+            "*",
+        );
+    });
+}

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,0 +1,4 @@
+# Writing a project that can use the GUI in Trailhead
+
+- Include a global `__template__` variable that points to a URL for the frontend. (ex. `__template__ == "https://example.com/my_gui`)
+- Include the `bridget.ts` file in your project and use the `executeCode` method that it exports. This method takes a generic representing the return type of the call, and will then return a promise of type `Promise<ExpectedReturnType>`. The only argument it expects is a stringified method call for a python function. (ex. `executeCode<ChessBoard>("makeMove('g4', 'f5')");`)

--- a/server/src/trailhead/app.py
+++ b/server/src/trailhead/app.py
@@ -127,6 +127,42 @@ async def repl_module(module: str, client: WebSocket):
             await client.close()
 
 
+@app.websocket("/ws/{module}/repl_gui")
+async def repl_gui(module: str, client: WebSocket):
+    """The FastAPI web socket endpoint dispatches out to Web Socket Manager."""
+    await client.accept()
+    try:
+        # Begin the async_python_subprocess
+        subprocess = AsyncPythonSubprocess(
+            module, client, "trailhead.wrappers.repl_gui"
+        )
+        pid = await subprocess.start()
+        response = WebSocketEvent(type="RUNNING", data={"pid": pid})
+        await client.send_text(response.model_dump_json())
+        while not subprocess.subprocess_exited():
+            try:
+                data = await asyncio.wait_for(client.receive_text(), timeout=0.1)
+                event = WebSocketEvent.model_validate_json(data)
+                match event.type:
+                    case "KILL":
+                        subprocess.kill()
+                    case "STDIN":
+                        subprocess.write(event.data["data"])
+
+            except asyncio.TimeoutError:
+                # Expected while waiting for client input
+                pass
+        await subprocess.await_end()
+    except Exception as e:
+        print(e, sys.stderr)
+    finally:
+        if not subprocess.subprocess_exited():
+            subprocess.kill()
+
+        if client.client_state == WebSocketState.CONNECTED:
+            await client.close()
+
+
 @app.websocket("/ws")
 async def websocket_endpoint(client: WebSocket):
     """The FastAPI web socket endpoint dispatches out to Web Socket Manager."""

--- a/server/src/trailhead/wrappers/repl_gui.py
+++ b/server/src/trailhead/wrappers/repl_gui.py
@@ -3,11 +3,9 @@ import traceback
 import json
 import ast
 import inspect
-
-# from pydantic import BaseModel, RootModel, SerializeAsAny
+from pydantic import BaseModel, RootModel, SerializeAsAny
 from typing import Any
-
-# from types import FunctionType
+from types import FunctionType
 
 if len(sys.argv) < 2:
     raise Exception("The module name must be passed as first argument to this wrapper.")
@@ -15,145 +13,145 @@ if len(sys.argv) < 2:
 module_name = sys.argv[1]
 
 
-# def audit_hook(event: str, args: tuple[Any, ...]):
-#     if event == "builtins.input":
-#         sys.stdout.buffer.write(b"\xff\xff\xff\xff")
-#         sys.stdout.write(f"{len(args[0])}\n")
+def audit_hook(event: str, args: tuple[Any, ...]):
+    if event == "builtins.input":
+        sys.stdout.buffer.write(b"\xff\xff\xff\xff")
+        sys.stdout.write(f"{len(args[0])}\n")
 
 
-# sys.addaudithook(audit_hook)
+sys.addaudithook(audit_hook)
 
-# ValueList = RootModel[list[SerializeAsAny[BaseModel]]]
-# ValueDict = RootModel[dict[str, SerializeAsAny[BaseModel]]]
-
-
-# class NoneValue(BaseModel):
-#     type: str = "none"
+ValueList = RootModel[list[SerializeAsAny[BaseModel]]]
+ValueDict = RootModel[dict[str, SerializeAsAny[BaseModel]]]
 
 
-# class IntValue(BaseModel):
-#     type: str = "int"
-#     value: int
+class NoneValue(BaseModel):
+    type: str = "none"
 
 
-# class FloatValue(BaseModel):
-#     type: str = "float"
-#     value: float
+class IntValue(BaseModel):
+    type: str = "int"
+    value: int
 
 
-# class StringValue(BaseModel):
-#     type: str = "str"
-#     value: str
+class FloatValue(BaseModel):
+    type: str = "float"
+    value: float
 
 
-# class BoolValue(BaseModel):
-#     type: str = "bool"
-#     value: bool
+class StringValue(BaseModel):
+    type: str = "str"
+    value: str
 
 
-# class Parameter(BaseModel):
-#     name: str
-#     type: str
-#     default_value: Any | None
+class BoolValue(BaseModel):
+    type: str = "bool"
+    value: bool
 
 
-# class Function(BaseModel):
-#     type: str = "function"
-#     name: str
-#     doc: str
-#     parameters: list[Parameter]
-#     return_type: str
-#     source: str
+class Parameter(BaseModel):
+    name: str
+    type: str
+    default_value: Any | None
 
 
-# class ListValue(BaseModel):
-#     type: str = "list"
-#     items: list[SerializeAsAny[BaseModel]]
+class Function(BaseModel):
+    type: str = "function"
+    name: str
+    doc: str
+    parameters: list[Parameter]
+    return_type: str
+    source: str
 
 
-# class DictValue(BaseModel):
-#     type: str = "dict"
-#     keys: list[SerializeAsAny[BaseModel]]
-#     values: list[SerializeAsAny[BaseModel]]
+class ListValue(BaseModel):
+    type: str = "list"
+    items: list[SerializeAsAny[BaseModel]]
 
 
-# class UnknownValue(BaseModel):
-#     type: str = "unknown"
-#     python_type: str
-#     value: str
+class DictValue(BaseModel):
+    type: str = "dict"
+    keys: list[SerializeAsAny[BaseModel]]
+    values: list[SerializeAsAny[BaseModel]]
 
 
-# class Context(BaseModel):
-#     type: str = "context"
-#     values: dict[str, SerializeAsAny[BaseModel]]
+class UnknownValue(BaseModel):
+    type: str = "unknown"
+    python_type: str
+    value: str
 
 
-# def bundle_globals(kvs: dict[str, Any]) -> Context:
-#     filtered = {k: v for k, v in kvs.items() if not k.startswith("_")}
-#     results = {}
-#     for k, v in filtered.items():
-#         results[k] = decompose_value(v)
-#     return Context(values=results)
+class Context(BaseModel):
+    type: str = "context"
+    values: dict[str, SerializeAsAny[BaseModel]]
 
 
-# def decompose_value(value: Any) -> BaseModel:
-#     if isinstance(value, bool):
-#         return BoolValue(value=value)
-#     elif isinstance(value, int):
-#         return IntValue(value=value)
-#     elif isinstance(value, float):
-#         return FloatValue(value=value)
-#     elif isinstance(value, str):
-#         return StringValue(value=value)
-#     elif value is None:
-#         return NoneValue()
-#     elif isinstance(value, FunctionType):
-#         return decompose_function(value)
-#     elif isinstance(value, list):
-#         return ListValue(items=[decompose_value(v) for v in value])
-#     elif isinstance(value, dict):
-#         return DictValue(
-#             keys=[decompose_value(k) for k in value.keys()],
-#             values=[decompose_value(v) for v in value.values()],
-#         )
-#     else:
-#         return UnknownValue(python_type=type(value).__name__, value=repr(value))
+def bundle_globals(kvs: dict[str, Any]) -> Context:
+    filtered = {k: v for k, v in kvs.items() if not k.startswith("_")}
+    results = {}
+    for k, v in filtered.items():
+        results[k] = decompose_value(v)
+    return Context(values=results)
 
 
-# def decompose_function(value: FunctionType) -> Function:
-#     parameters = []
-#     signature = inspect.signature(value)
-#     for name, param in signature.parameters.items():
-#         parameters.append(
-#             Parameter(
-#                 name=name,
-#                 type=(
-#                     getattr(param.annotation, "__name__", str(param.annotation))
-#                     if param.annotation != inspect._empty
-#                     else "Any"
-#                 ),
-#                 default_value=(
-#                     None if param.default is inspect._empty else param.default
-#                 ),
-#             )
-#         )
-#     return Function(
-#         type="function",
-#         name=value.__name__,
-#         doc=value.__doc__ or "",
-#         parameters=parameters,
-#         return_type=getattr(
-#             signature.return_annotation, "__name__", str(signature.return_annotation)
-#         ),
-#         source=inspect.getsource(value),
-#     )
+def decompose_value(value: Any) -> BaseModel:
+    if isinstance(value, bool):
+        return BoolValue(value=value)
+    elif isinstance(value, int):
+        return IntValue(value=value)
+    elif isinstance(value, float):
+        return FloatValue(value=value)
+    elif isinstance(value, str):
+        return StringValue(value=value)
+    elif value is None:
+        return NoneValue()
+    elif isinstance(value, FunctionType):
+        return decompose_function(value)
+    elif isinstance(value, list):
+        return ListValue(items=[decompose_value(v) for v in value])
+    elif isinstance(value, dict):
+        return DictValue(
+            keys=[decompose_value(k) for k in value.keys()],
+            values=[decompose_value(v) for v in value.values()],
+        )
+    else:
+        return UnknownValue(python_type=type(value).__name__, value=repr(value))
 
 
-# def print_context(context: dict[str, Any]):
-#     filtered_globals = bundle_globals(context)
-#     sys.stderr.write(str(filtered_globals.model_dump_json()))
-#     sys.stderr.write("\n")
-#     sys.stderr.flush()
+def decompose_function(value: FunctionType) -> Function:
+    parameters = []
+    signature = inspect.signature(value)
+    for name, param in signature.parameters.items():
+        parameters.append(
+            Parameter(
+                name=name,
+                type=(
+                    getattr(param.annotation, "__name__", str(param.annotation))
+                    if param.annotation != inspect._empty
+                    else "Any"
+                ),
+                default_value=(
+                    None if param.default is inspect._empty else param.default
+                ),
+            )
+        )
+    return Function(
+        type="function",
+        name=value.__name__,
+        doc=value.__doc__ or "",
+        parameters=parameters,
+        return_type=getattr(
+            signature.return_annotation, "__name__", str(signature.return_annotation)
+        ),
+        source=inspect.getsource(value),
+    )
+
+
+def print_context(context: dict[str, Any]):
+    filtered_globals = bundle_globals(context)
+    sys.stderr.write(str(filtered_globals.model_dump_json()))
+    sys.stderr.write("\n")
+    sys.stderr.flush()
 
 
 def exec_callback(result: Any, globals: dict[str, Any], statement_ast: ast.Module):
@@ -164,7 +162,7 @@ def exec_callback(result: Any, globals: dict[str, Any], statement_ast: ast.Modul
 
     if result is not None:
         sys.stderr.write(
-            f'{{"type": "expr_eval", "value": {json.dumps(result, default=lambda o: o.__dict__)}}}'
+            f'{{"type": "expr_eval", "value": {decompose_value(result).model_dump_json()}, "raw_value": {json.dumps(result, default=lambda o: o.__dict__)}}}'
         )
         sys.stderr.write("\n")
         sys.stderr.flush()

--- a/server/src/trailhead/wrappers/repl_gui.py
+++ b/server/src/trailhead/wrappers/repl_gui.py
@@ -1,0 +1,254 @@
+import sys
+import traceback
+import json
+import ast
+import inspect
+
+# from pydantic import BaseModel, RootModel, SerializeAsAny
+from typing import Any
+
+# from types import FunctionType
+
+if len(sys.argv) < 2:
+    raise Exception("The module name must be passed as first argument to this wrapper.")
+
+module_name = sys.argv[1]
+
+
+# def audit_hook(event: str, args: tuple[Any, ...]):
+#     if event == "builtins.input":
+#         sys.stdout.buffer.write(b"\xff\xff\xff\xff")
+#         sys.stdout.write(f"{len(args[0])}\n")
+
+
+# sys.addaudithook(audit_hook)
+
+# ValueList = RootModel[list[SerializeAsAny[BaseModel]]]
+# ValueDict = RootModel[dict[str, SerializeAsAny[BaseModel]]]
+
+
+# class NoneValue(BaseModel):
+#     type: str = "none"
+
+
+# class IntValue(BaseModel):
+#     type: str = "int"
+#     value: int
+
+
+# class FloatValue(BaseModel):
+#     type: str = "float"
+#     value: float
+
+
+# class StringValue(BaseModel):
+#     type: str = "str"
+#     value: str
+
+
+# class BoolValue(BaseModel):
+#     type: str = "bool"
+#     value: bool
+
+
+# class Parameter(BaseModel):
+#     name: str
+#     type: str
+#     default_value: Any | None
+
+
+# class Function(BaseModel):
+#     type: str = "function"
+#     name: str
+#     doc: str
+#     parameters: list[Parameter]
+#     return_type: str
+#     source: str
+
+
+# class ListValue(BaseModel):
+#     type: str = "list"
+#     items: list[SerializeAsAny[BaseModel]]
+
+
+# class DictValue(BaseModel):
+#     type: str = "dict"
+#     keys: list[SerializeAsAny[BaseModel]]
+#     values: list[SerializeAsAny[BaseModel]]
+
+
+# class UnknownValue(BaseModel):
+#     type: str = "unknown"
+#     python_type: str
+#     value: str
+
+
+# class Context(BaseModel):
+#     type: str = "context"
+#     values: dict[str, SerializeAsAny[BaseModel]]
+
+
+# def bundle_globals(kvs: dict[str, Any]) -> Context:
+#     filtered = {k: v for k, v in kvs.items() if not k.startswith("_")}
+#     results = {}
+#     for k, v in filtered.items():
+#         results[k] = decompose_value(v)
+#     return Context(values=results)
+
+
+# def decompose_value(value: Any) -> BaseModel:
+#     if isinstance(value, bool):
+#         return BoolValue(value=value)
+#     elif isinstance(value, int):
+#         return IntValue(value=value)
+#     elif isinstance(value, float):
+#         return FloatValue(value=value)
+#     elif isinstance(value, str):
+#         return StringValue(value=value)
+#     elif value is None:
+#         return NoneValue()
+#     elif isinstance(value, FunctionType):
+#         return decompose_function(value)
+#     elif isinstance(value, list):
+#         return ListValue(items=[decompose_value(v) for v in value])
+#     elif isinstance(value, dict):
+#         return DictValue(
+#             keys=[decompose_value(k) for k in value.keys()],
+#             values=[decompose_value(v) for v in value.values()],
+#         )
+#     else:
+#         return UnknownValue(python_type=type(value).__name__, value=repr(value))
+
+
+# def decompose_function(value: FunctionType) -> Function:
+#     parameters = []
+#     signature = inspect.signature(value)
+#     for name, param in signature.parameters.items():
+#         parameters.append(
+#             Parameter(
+#                 name=name,
+#                 type=(
+#                     getattr(param.annotation, "__name__", str(param.annotation))
+#                     if param.annotation != inspect._empty
+#                     else "Any"
+#                 ),
+#                 default_value=(
+#                     None if param.default is inspect._empty else param.default
+#                 ),
+#             )
+#         )
+#     return Function(
+#         type="function",
+#         name=value.__name__,
+#         doc=value.__doc__ or "",
+#         parameters=parameters,
+#         return_type=getattr(
+#             signature.return_annotation, "__name__", str(signature.return_annotation)
+#         ),
+#         source=inspect.getsource(value),
+#     )
+
+
+# def print_context(context: dict[str, Any]):
+#     filtered_globals = bundle_globals(context)
+#     sys.stderr.write(str(filtered_globals.model_dump_json()))
+#     sys.stderr.write("\n")
+#     sys.stderr.flush()
+
+
+def exec_callback(result: Any, globals: dict[str, Any], statement_ast: ast.Module):
+    # TODO: Interesting things in the event of statements such as:
+    # 1. Assignment Statement - Print the value of the assigned variable and
+    # name of variable
+    # print(ast.dump(statement_ast))
+
+    if result is not None:
+        sys.stderr.write(
+            f'{{"type": "expr_eval", "value": {json.dumps(result, default=lambda o: o.__dict__)}}}'
+        )
+        sys.stderr.write("\n")
+        sys.stderr.flush()
+
+
+try:
+    import importlib
+    from .interact.repl import InteractiveConsole
+
+    module = importlib.import_module(module_name)
+    local_scope = vars(module).copy()
+    console = InteractiveConsole(locals=local_scope, exec_callback=exec_callback)
+    console.interact(banner="")
+
+except Exception as e:
+    tb_info = traceback.extract_tb(e.__traceback__)
+    frames = inspect.getinnerframes(e.__traceback__)  # type: ignore
+
+    stack_trace: list[dict[str, Any]] = []
+
+    info_frames = [frame for frame in tb_info]
+    stack_frames = [frame for frame in frames]
+
+    for i in range(len(info_frames)):
+        frame = info_frames[i]
+        stack_frame = stack_frames[i]
+
+        if (
+            frame.filename.startswith("/workspace/server")
+            or frame.filename.startswith("/usr/lib")
+            or frame.filename.startswith("<frozen importlib")
+        ):
+            continue
+
+        arguments = inspect.getargvalues(stack_frame.frame)
+
+        locals: dict[str, Any] = {}
+        for local in stack_frame.frame.f_locals:
+            value = stack_frame.frame.f_locals[local]
+            try:
+                json.dumps(value)
+                locals[local] = value
+                # except (TypeError, OverflowError):
+                #     try:
+                #         value_type = type(value)
+
+                #             attributes = [
+                #                 attr for attr in dir(value) if not attr.startswith("_")
+                #             ]
+                #             simple_object: dict[str, Any] = {}
+
+                #             for attr in attributes:
+                #                 simple_object[attr] = getattr(value, attr)
+
+                #             locals[local] = {
+                #                 "type": type(value).__name__,
+                #                 "repr": attributes,
+                #             }
+                #         else:
+                #             locals[local] = repr(value)
+            except (TypeError, OverflowError):
+                locals[local] = "[See value in Debugger]"
+                continue
+
+        stack_trace.append(
+            {
+                "filename": frame.filename.replace("/workspace/", ""),
+                "lineno": frame.lineno,
+                "name": frame.name,
+                "line": "".join(stack_frame.code_context),  # type: ignore
+                "end_lineno": frame.end_lineno,
+                "colno": frame.colno,
+                "end_colno": frame.end_colno,
+                "locals": locals,
+            }
+        )
+
+    error_info = {
+        "type": type(e).__name__,
+        "message": str(e),
+        "stack_trace": stack_trace,
+    }
+
+    json_error_info = json.dumps(error_info)
+
+    sys.stderr.write(f"{json_error_info}\n")
+    sys.exit(1)

--- a/server/src/trailhead/wrappers/repl_gui.py
+++ b/server/src/trailhead/wrappers/repl_gui.py
@@ -160,12 +160,11 @@ def exec_callback(result: Any, globals: dict[str, Any], statement_ast: ast.Modul
     # name of variable
     # print(ast.dump(statement_ast))
 
-    if result is not None:
-        sys.stderr.write(
-            f'{{"type": "expr_eval", "value": {decompose_value(result).model_dump_json()}, "raw_value": {json.dumps(result, default=lambda o: o.__dict__)}}}'
-        )
-        sys.stderr.write("\n")
-        sys.stderr.flush()
+    sys.stderr.write(
+        f'{{"type": "expr_eval", "value": {decompose_value(result).model_dump_json()}, "raw_value": {json.dumps(result, default=lambda o: o.__dict__)}}}'
+    )
+    sys.stderr.write("\n")
+    sys.stderr.flush()
 
 
 try:


### PR DESCRIPTION
This PR adds in the necessary files to allow to GUIs to be displayed in trailhead, with their backend powered by a local python script.

This is accomplished via a `__template__` variable specified in the top level of a python file, which points to the URL for the frontend. The frontend then uses the `docs/bridge.ts` file to make remote procedure calls to the python file.